### PR TITLE
Truffle config robustify

### DIFF
--- a/contracts/ERC1155Tradable.sol
+++ b/contracts/ERC1155Tradable.sol
@@ -155,6 +155,23 @@ contract ERC1155Tradable is ERC1155, ERC1155MintBurn, ERC1155Metadata, Ownable {
   }
 
   /**
+    * @dev Change the creator address for given tokens
+    * @param _to   Address of the new creator
+    * @param _ids  Array of Token IDs to change creator
+    */
+  function setCreator(
+    address _to,
+    uint256[] memory _ids
+  ) public {
+    require(_to != address(0), "ERC1155Tradable#setCreator: INVALID_ADDRESS.");
+    for (uint256 i = 0; i < _ids.length; i++) {
+      uint256 id = _ids[i];
+      require(creators[id] == msg.sender, "ERC1155Tradable#setCreator: ONLY_CREATOR_ALLOWED");
+      creators[id] = _to;
+    }
+  }
+
+  /**
    * Override isApprovedForAll to whitelist user's OpenSea proxy accounts to enable gas-free listings.
    */
   function isApprovedForAll(

--- a/contracts/ERC1155Tradable.sol
+++ b/contracts/ERC1155Tradable.sol
@@ -129,7 +129,7 @@ contract ERC1155Tradable is ERC1155, ERC1155MintBurn, ERC1155Metadata, Ownable {
     bytes memory _data
   ) public creatorOnly(_id) {
     _mint(_to, _id, _quantity, _data);
-    tokenSupply[_id] += _quantity;
+    tokenSupply[_id] = tokenSupply[_id].add(_quantity);
   }
 
   /**
@@ -149,7 +149,7 @@ contract ERC1155Tradable is ERC1155, ERC1155MintBurn, ERC1155Metadata, Ownable {
       uint256 _id = _ids[i];
       require(creators[_id] == msg.sender, "ERC1155Tradable#batchMint: ONLY_CREATOR_ALLOWED");
       uint256 quantity = _quantities[i];
-      tokenSupply[_id] += quantity;
+      tokenSupply[_id] = tokenSupply[_id].add(quantity);
     }
     _batchMint(_to, _ids, _quantities, _data);
   }

--- a/contracts/MyFactory.sol
+++ b/contracts/MyFactory.sol
@@ -1,12 +1,13 @@
 pragma solidity ^0.5.11;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "openzeppelin-solidity/contracts/utils/ReentrancyGuard.sol";
 import "./IFactory.sol";
 import "./MyCollectible.sol";
 import "./Strings.sol";
 
 // WIP
-contract MyFactory is IFactory, Ownable {
+contract MyFactory is IFactory, Ownable, ReentrancyGuard {
   using Strings for string;
   using SafeMath for uint256;
 
@@ -65,7 +66,7 @@ contract MyFactory is IFactory, Ownable {
     return _canMint(msg.sender, Option(_optionId), _amount);
   }
 
-  function mint(uint256 _optionId, address _toAddress, uint256 _amount, bytes calldata _data) external {
+  function mint(uint256 _optionId, address _toAddress, uint256 _amount, bytes calldata _data) external nonReentrant() {
     return _mint(Option(_optionId), _toAddress, _amount, _data);
   }
 

--- a/contracts/TestForReentrancyAttack.sol
+++ b/contracts/TestForReentrancyAttack.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.11;
+
+import "./MyCollectible.sol";
+import "./MyFactory.sol";
+
+contract TestForReentrancyAttack is MyCollectible {
+  address public factoryAddress;
+  bool private inMintingCall = false;
+
+  constructor(address _proxyRegistryAddress)
+    MyCollectible(_proxyRegistryAddress) public {}
+
+  function setFactoryAddress(address _factoryAddress) public {
+    factoryAddress = _factoryAddress;
+  }
+
+  function create(
+    address _addr,
+    uint256 _amount,
+    string calldata,
+    bytes calldata _b
+  ) external returns (uint256) {
+    if (!inMintingCall) {
+      inMintingCall = true;
+      MyFactory factory = MyFactory(factoryAddress);
+      factory.mint(1, _addr, _amount, _b);
+    }
+    inMintingCall = false;
+    return 0;
+  }
+
+  function mint(address, uint256, uint256, bytes memory) public {}
+}

--- a/test/ERC1155Tradable.js
+++ b/test/ERC1155Tradable.js
@@ -1,0 +1,104 @@
+/* Contracts in this test */
+const ERC1155Tradable = artifacts.require("../contracts/ERC1155Tradable.sol");
+
+/* Necessary packages */
+const BN = web3.utils.BN;
+
+/* Utility functions */
+const expectThrow = require('./helpers/expectThrow.js');
+
+contract("ERC1155Tradable - ERC 1155", (accounts) => {
+	var instance,
+		owner = accounts[0],
+		creator = accounts[1],
+		userA = accounts[2],
+		userB = accounts[3];
+
+	var name = 'ERC-1155 Test Contract',
+		symbol = 'ERC1155Test';
+
+	var initialTokenId = 1;
+		initialTokenSupply = new BN(2, 10),
+		mintAmount = new BN(2, 10);
+
+	var overflowNumber = (new BN(2, 10)).pow(new BN(256, 10)).sub(new BN(1, 10));
+
+	// Rinkeby proxy address for test, doesn't actually work in the test
+	// since the contract does not exist in the test environment.
+	var proxyAddress = '0xf57b2c51ded3a29e6891aba85459d600256cf317';
+
+	before(async () => {
+		instance = await ERC1155Tradable.new(name, symbol, proxyAddress);
+	});
+
+	describe('Setup & Defaults', () => {
+		it('Verify the name and symbol are set',
+			() => instance.name()
+			.then((_name) => {
+				assert.equal(name, _name);
+				return instance.symbol();
+			})
+			.then((_symbol) => {
+				assert.equal(symbol, _symbol);
+			})
+		);
+	});
+
+	describe('Creating tokens', () => {
+		it('Owner can create tokens',
+			() => instance.create(owner, 0, "", "0x0", {from: owner})
+			.then((_tx) => {
+				assert.ok(_tx, "Failed to create token:" + _tx);
+				return instance.uri(initialTokenId);
+			})
+			.then((_uri) => {
+				assert.equal(_uri, String(initialTokenId));
+			})
+		);
+
+		it('Non-owner can not create tokens',
+			() => expectThrow(instance.create(userA, 0, "", "0x0", {from: userA}))
+		);
+	});
+
+	describe('Minting', () => {
+		it('Mint some tokens, get correct totalSupply back',
+			() => instance.mint(userA, initialTokenId, mintAmount, "0x0", {from: owner})
+			.then(() => {
+				return instance.totalSupply(initialTokenId);
+			})
+			.then((_supply) => {
+				assert(mintAmount.eq(_supply));
+				initialTokenSupply = _supply
+			})
+		);
+
+		it('Minting should not overflow',
+			() => expectThrow(
+				instance.mint(userB, initialTokenId, overflowNumber, "0x0", {from: owner}),
+				'OVERFLOW'
+			)
+		);
+	});
+
+	describe('Batch Minting', () => {
+		it('Batch mint some tokens, get correct totalSupply back',
+			() => instance.batchMint(userA, [initialTokenId], [mintAmount], "0x0", {from: owner})
+			.then(() => {
+				return instance.totalSupply(initialTokenId);
+			})
+			.then((_supply) => {
+				assert(initialTokenSupply.add(mintAmount).eq(_supply));
+				initialTokenSupply = _supply;
+			})
+		);
+
+		it('Batch minting should not overflow',
+			() => expectThrow(
+				instance.mint(userB, initialTokenId, overflowNumber, "0x0", {from: owner}),
+				'OVERFLOW'
+			)
+		);
+	});
+
+});

--- a/test/MyFactory.js
+++ b/test/MyFactory.js
@@ -1,0 +1,57 @@
+/* Contracts in this test */
+const MyFactory = artifacts.require("../contracts/MyFactory.sol");
+const TestForReentrancyAttack = artifacts.require("../contracts/TestForReentrancyAttack.sol");
+
+/* Utility functions */
+const expectThrow = require('./helpers/expectThrow.js');
+
+contract("MyFactory - ERC 1155", (accounts) => {
+	var myFactory,
+		myCollectible,
+		proxy,
+		owner = accounts[0],
+		userA = accounts[1];
+
+	// Rinkeby proxy address for test, doesn't actually work in the test
+	// since the contract does not exist in the test environment.
+	var proxyAddress = '0xf57b2c51ded3a29e6891aba85459d600256cf317';
+
+	before(async () => {
+		myCollectible = await TestForReentrancyAttack.new(proxyAddress);
+		myFactory = await MyFactory.new(proxyAddress, myCollectible.address);
+		await myCollectible.setFactoryAddress(myFactory.address);
+	});
+
+	/**
+	 * NOTE: This check is difficult to test in a development
+	 * environment, due to the OwnableDelegateProxy. To get around
+	 * this, in order to test this function below, you'll need to:
+	 *
+	 * 1. go to MyFactory.sol, and
+	 * 2. modify _isOwnerOrProxy
+	 *
+	 * --> Modification is:
+	 *      comment out
+	 *         return owner() == _address || address(proxyRegistry.proxies(owner())) == _address;
+	 *      replace with
+	 *         return true;
+	 * Then run, you'll get the reentrant error, which passes the test
+	 **/
+
+	describe('Re-Entrancy Check', () => {
+		it('Should have the correct factory address set',
+			() => myCollectible.factoryAddress()
+			.then((_factoryAddress) => {
+				assert.equal(myFactory.address, _factoryAddress);
+			})
+		);
+
+		it('Minting from factory should disallow re-entrancy attack',
+			() => expectThrow(
+				myFactory.mint(1, userA, 1, "0x0", {from: owner}),
+				'reentrant'
+			)
+		);
+	});
+
+});

--- a/test/helpers/expectThrow.js
+++ b/test/helpers/expectThrow.js
@@ -1,0 +1,22 @@
+module.exports = async function(promise, errorMessageSearch = null) {
+    try {
+        await promise;
+    } catch (error) {
+        if (errorMessageSearch) {
+            assert(
+                error.message.search(errorMessageSearch) >= 0,
+                'Expected specific error message ' + errorMessageSearch + ', received:' + error
+            );
+            return;
+        }
+
+        let invalidOpcode = error.message.search('invalid opcode') >= 0;
+        let outOfGas = error.message.search('out of gas') >= 0;
+        let revert = error.message.search('revert') >= 0;
+
+        assert(invalidOpcode || outOfGas || revert, 'Unexpected thrown error: \'' + error);
+        return;
+    }
+
+    assert.fail('Expected throw not received');
+};

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -22,8 +22,9 @@ const HDWalletProvider = require('truffle-hdwallet-provider');
 const MNEMONIC = process.env.MNEMONIC;
 const INFURA_KEY = process.env.INFURA_KEY;
 
-const needsInfura = process.env.npm_config_argv.includes('rinkeby') ||
-  process.env.npm_config_argv.includes('live');
+const needsInfura = process.env.npm_config_argv &&
+      (process.env.npm_config_argv.includes('rinkeby') ||
+       process.env.npm_config_argv.includes('live'));
 
 if ((!MNEMONIC || !INFURA_KEY) && needsInfura) {
   console.error('Please set a mnemonic and infura key.');


### PR DESCRIPTION
This updates truffle-config.js to run in the absence of process.env.npm_config_argv , which seems to be the case when invoking vanilla `truffle test` to run individual tests.

It does not otherwise affect truffle's behavior.